### PR TITLE
Remove domain-scoped project declaration

### DIFF
--- a/example-workflows/cloud-run/.github/workflows/cloud-run.yml
+++ b/example-workflows/cloud-run/.github/workflows/cloud-run.yml
@@ -45,7 +45,7 @@ jobs:
       run: |-
         gcloud builds submit \
           --quiet \
-          --tag "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA"
+          --tag "gcr.io/$PROJECT_ID/$SERVICE_NAME/$GITHUB_SHA"
 
     # Deploy image to Cloud Run
     - name: Deploy
@@ -53,6 +53,6 @@ jobs:
         gcloud run deploy "$SERVICE_NAME" \
           --quiet \
           --region "$RUN_REGION" \
-          --image "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA" \
+          --image "gcr.io/$PROJECT_ID/$SERVICE_NAME/$GITHUB_SHA" \
           --platform "managed" \
           --allow-unauthenticated


### PR DESCRIPTION
Fixes: avoid Build Exit Error 125
Description:
Domain-scoped projects
If your project is scoped to your domain, the project ID includes the name of the domain followed by a colon (:). Because of how Docker treats colons, you must replace the colon character with a forward slash when you specify an image digest in Container Registry. Identify images in these types of projects using the following format:

HOSTNAME/[DOMAIN]/[PROJECT]/IMAGE

Source: https://cloud.google.com/container-registry/docs/overview#domain-scoped_projects