### PR TITLE
fix: bump @actions/tool-cache to 1.6.1

### DIFF
--- a/setup-gcloud/package-lock.json
+++ b/setup-gcloud/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.9.tgz",
+      "integrity": "sha512-0O4SsJ7q+MK0ycvXPl2e6bMXV7dxAXOGjrXS1eTF9s2S401Tp6c/P3c3Joz04QefC1J6Gt942Wl2jbm3f4mLcg==",
       "requires": {
         "tunnel": "0.0.6"
       }
@@ -31,13 +31,13 @@
       "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "@actions/tool-cache": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.3.3.tgz",
-      "integrity": "sha512-AFVyTLcIxusDVI1gMhbZW8m/On7YNJG+xYaxorV+qic+f7lO7h37aT2mfzxqAq7mwHxtP1YlVFNrXe9QDf/bPg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.1.tgz",
+      "integrity": "sha512-F+vwEDwfqcHMKuSkj79pihOnsAMv23EkG76nMpc82UsnXwyQdyEsktGxrB0SNtm7pRqTXEIOoAPTgrSQclXYTg==",
       "requires": {
-        "@actions/core": "^1.2.0",
+        "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.0",
-        "@actions/http-client": "^1.0.3",
+        "@actions/http-client": "^1.0.8",
         "@actions/io": "^1.0.1",
         "semver": "^6.1.0",
         "uuid": "^3.3.2"

--- a/setup-gcloud/package.json
+++ b/setup-gcloud/package.json
@@ -27,7 +27,7 @@
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.3",
     "@actions/io": "^1.0.2",
-    "@actions/tool-cache": "^1.3.1",
+    "@actions/tool-cache": "^1.6.1",
     "@lifeomic/attempt": "^3.0.0",
     "semver": "^7.1.3",
     "tmp": "^0.1.0",

--- a/setupGcloudSDK/package-lock.json
+++ b/setupGcloudSDK/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.9.tgz",
+      "integrity": "sha512-0O4SsJ7q+MK0ycvXPl2e6bMXV7dxAXOGjrXS1eTF9s2S401Tp6c/P3c3Joz04QefC1J6Gt942Wl2jbm3f4mLcg==",
       "requires": {
         "tunnel": "0.0.6"
       }
@@ -31,13 +31,13 @@
       "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "@actions/tool-cache": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.3.3.tgz",
-      "integrity": "sha512-AFVyTLcIxusDVI1gMhbZW8m/On7YNJG+xYaxorV+qic+f7lO7h37aT2mfzxqAq7mwHxtP1YlVFNrXe9QDf/bPg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.1.tgz",
+      "integrity": "sha512-F+vwEDwfqcHMKuSkj79pihOnsAMv23EkG76nMpc82UsnXwyQdyEsktGxrB0SNtm7pRqTXEIOoAPTgrSQclXYTg==",
       "requires": {
-        "@actions/core": "^1.2.0",
+        "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.0",
-        "@actions/http-client": "^1.0.3",
+        "@actions/http-client": "^1.0.8",
         "@actions/io": "^1.0.1",
         "semver": "^6.1.0",
         "uuid": "^3.3.2"

--- a/setupGcloudSDK/package.json
+++ b/setupGcloudSDK/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
-    "@actions/tool-cache": "^1.3.3",
+    "@actions/tool-cache": "^1.6.1",
     "@lifeomic/attempt": "^3.0.0",
     "@types/tmp": "^0.1.0",
     "tmp": "^0.1.0",


### PR DESCRIPTION
@actions/tool-cache does not seem to use addPath or exportVariable but bumping to latest patched versions