### PR TITLE
fix: add GITHUB_PATH to unit test process stub

### DIFF
--- a/setup-gcloud/tests/setup-gcloud.test.ts
+++ b/setup-gcloud/tests/setup-gcloud.test.ts
@@ -57,7 +57,7 @@ describe('#run', function() {
       parseServiceAccountKey: sinon.stub(setupGcloud, 'parseServiceAccountKey'),
       toolCacheFind: sinon.stub(toolCache, 'find').returns('/'),
       writeFile: sinon.stub(fs, 'writeFile'),
-      env: sinon.stub(process, 'env').value({}),
+      env: sinon.stub(process, 'env').value({ GITHUB_PATH: '/' }),
     };
   });
 


### PR DESCRIPTION
`GITHUB_PATH` is required to activate new method of appending to path
https://github.com/actions/toolkit/blob/e7eb2c741847a05686a1b8df93dea4b244640b17/packages/core/src/core.ts#L67-L75