### PR TITLE
Added minimum required role to deploy-cloudrun/README.md

### DIFF
--- a/deploy-cloudrun/README.md
+++ b/deploy-cloudrun/README.md
@@ -125,9 +125,12 @@ automatically private services, while deploying a revision of a public
 There are a few ways to authenticate this action. A service account will be needed
 with the following roles:
 
-- Cloud Run Admin (`roles/run.admin`):
+- Cloud Run Admin (`run.admin`):
   - Can create, update, and delete services.
   - Can get and set IAM policies.
+- Cloud Functions Developer (`cloudfunctions.developer`):
+  - Can create, update, and delete functions.
+  - Can't set IAM policies but can view source code.
 
 This service account needs to a member of the `Compute Engine default service account`,
 `(PROJECT_NUMBER-compute@developer.gserviceaccount.com)`, with role

--- a/deploy-cloudrun/README.md
+++ b/deploy-cloudrun/README.md
@@ -125,10 +125,10 @@ automatically private services, while deploying a revision of a public
 There are a few ways to authenticate this action. A service account will be needed
 with the following roles:
 
-- Cloud Run Admin (`run.admin`):
+- Cloud Run Admin (`roles/run.admin`):
   - Can create, update, and delete services.
   - Can get and set IAM policies.
-- Cloud Functions Developer (`cloudfunctions.developer`):
+- Cloud Functions Developer (`roles/cloudfunctions.developer`):
   - Can create, update, and delete functions.
   - Can't set IAM policies but can view source code.
 


### PR DESCRIPTION
This Workflow requires the cloudfunctions.functions.sourceCodeSet permission, provided by the Cloud Functions Developer role. 

Added the Cloud Functions Developer role to the Authorization roles listing in the documentation. 

Really appreciate the work!!