### PR TITLE
Update README.md

### DIFF
--- a/example-workflows/gke/README.md
+++ b/example-workflows/gke/README.md
@@ -71,7 +71,7 @@ For pushes to the `master` branch, this workflow will:
 
     - `GKE_CLUSTER` - the instance name of your cluster
 
-    - `GCE_ZONE` - the zone your cluster resides
+    - `GKE_ZONE` - the zone your cluster resides
 
     - `IMAGE` - your preferred Docker image name
 


### PR DESCRIPTION
`GCE_ZONE` was used in the README, but `GKE_ZONE` is used in gke.yml.