### PR TITLE
chore: fix branch name for integration tests

### DIFF
--- a/.github/workflows/setup-gcloud-it.yml
+++ b/.github/workflows/setup-gcloud-it.yml
@@ -3,7 +3,7 @@ name: setup-gcloud Integration
 on:
   push:
     branches:
-    - 'main'
+    - 'master'
     pull_request:
 
 jobs:


### PR DESCRIPTION
Integration tests were not running due to wrong branch name