### PR TITLE
chore: update branch name for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: 'release'
 on:
   push:
     branches:
-    - 'main'
+    - 'master'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We haven't switched from master to main in this repo yet and this is blocking build. I will create a follow up PR once I rename the branch.
