### PR TITLE
Document that WIF is supported for gsutil and bq now

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,8 @@ authenticate via:
 
 ### Workload Identity Federation (preferred)
 
-**⚠️ The `bq` and `gsutil` tools do not currently support Workload Identity
-Federation!** You will need to use traditional service account key
-authentication for now.
+**⚠️ You must use the Cloud SDK version 390.0.0 or later to authenticate the
+`bq` and `gsutil` tools.**
 
 ```yaml
 jobs:


### PR DESCRIPTION
Hello :wave:
Thank you for providing useful actions for GCP users!

I've confirmed that WIF is supported even for `gsutil` and `bq` commands. I also found [another post that commented WIF worked with the `gsutil` command](https://github.com/GoogleCloudPlatform/gsutil/issues/1407#issuecomment-1165320798).

So here I want to suggest a documentation update to provide the same description with [`google-github-actions/auth`](https://github.com/google-github-actions/auth).

refs https://github.com/google-github-actions/auth/pull/213
