### PR TITLE
fix: suggest v1 instead of v0

### DIFF
--- a/src/setup-gcloud.ts
+++ b/src/setup-gcloud.ts
@@ -36,7 +36,7 @@ export const GCLOUD_METRICS_LABEL = 'github-actions-setup-gcloud';
 export async function run(): Promise<void> {
   // Warn if pinned to HEAD
   if (isPinnedToHead()) {
-    core.warning(pinnedToHeadWarning('v0'));
+    core.warning(pinnedToHeadWarning('v1'));
   }
 
   core.exportVariable(GCLOUD_METRICS_ENV_VAR, GCLOUD_METRICS_LABEL);


### PR DESCRIPTION
Thanks for releasing v1, it encourages me to keep using fresh releases!

Here I'll suggest a minor fix, which helps users to use the latest release instead of v0.