### PR TITLE
Add warning about `skip_install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ jobs:
     improve workflow speeds at the expense of a slightly older gcloud version.
     Setting this to `true` ignores any value for the `version` input. If you
     skip installation, you will be unable to install components because the
-    system-install gcloud is locked. The default value is `false`.
+    system-install gcloud is locked. The default value is `false`. ⚠️ Be aware
+    that GitHub [plans to remove](https://github.com/actions/runner-images/issues/7101)
+    the system-installed gcloud, so this option might result in the workflow
+    breaking at some point in the future.
 
 -   `version`: (Optional) A string representing the version or version
     constraint of the Cloud SDK (`gcloud`) to install (e.g. `"290.0.1"` or `">=

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ jobs:
     skip installation, you will be unable to install components because the
     system-install gcloud is locked. The default value is `false`. ⚠️ Be aware
     that GitHub [plans to remove](https://github.com/actions/runner-images/issues/7101)
-    the system-installed gcloud, so this option might result in the workflow
-    breaking at some point in the future.
+    the system-installed gcloud, and any workflows with `skip_install: true`
+    will stop working when that happens.
 
 -   `version`: (Optional) A string representing the version or version
     constraint of the Cloud SDK (`gcloud`) to install (e.g. `"290.0.1"` or `">=


### PR DESCRIPTION
Based on github's comments in https://github.com/actions/runner-images/issues/7101 it's my understanding that at some point the system-installed gcloud will no longer be included in the runners. When that happens, I assume any workflows with `skip_install: true` will stop working

(also fyi: the readme [references](https://github.com/google-github-actions/setup-gcloud#contributing) CONTRIBUTING.md, but that file doesn't exist)