### PR TITLE
feat: Added optional inputs 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,28 @@ inputs:
       at other inputs and environment variables.
     required: false
 
+  workload_identity_provider:
+    description: |-
+      The full identifier of the Workload Identity Provider, including the
+      project number, pool name, and provider name. If provided, this must be
+      the full identifier which includes all parts, for example:
+      "projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider".
+      This is mutually exclusive with "credentials_json".
+    required: false
+
+  service_account:
+    description: |-
+      Email address or unique identifier of the Google Cloud service account for
+      which to generate credentials. This is required if
+      "workload_identity_provider" is specified.
+    required: false
+
+  credentials_json:
+    description: |-
+      The Google Cloud JSON service account key to use for authentication. This
+      is mutually exclusive with "workload_identity_provider".
+    required: false
+
   install_components:
     description: |-
       List of additional [gcloud


### PR DESCRIPTION
Added the optional inputs: workload_identity_provider, service_account, credentials_json

Without these declared in action.yml, Github runners will keep throwing "Unexpected input(s)" warnings whenever the action is run.

<img width="1051" alt="Screenshot 2024-10-12 at 02 03 47" src="https://github.com/user-attachments/assets/c1651f91-b637-4af1-81e6-2e3aa0a6ef76">
<img width="1023" alt="Screenshot 2024-10-12 at 02 03 32" src="https://github.com/user-attachments/assets/7cbcf65c-9283-4a07-b114-4fe0fc9b6f78">
